### PR TITLE
Use ReactDOM.findDOMNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 var Dropzone = React.createClass({
 
@@ -92,7 +93,7 @@ var Dropzone = React.createClass({
   },
 
   open: function() {
-    var fileInput = React.findDOMNode(this.refs.fileInput);
+    var fileInput = ReactDOM.findDOMNode(this.refs.fileInput);
     fileInput.value = null;
     fileInput.click();
   },


### PR DESCRIPTION
React.findDOMNode is deprecated. I updated the code to use ReactDOM.findDOMNode from require('react-dom') instead.
